### PR TITLE
Add option to set number of threads used

### DIFF
--- a/DCA/__main__.py
+++ b/DCA/__main__.py
@@ -41,6 +41,8 @@ def parse_args():
             help="Type of autoencoder. Possible values: normal, poisson, nb, "
                  "nb-shared, nb-conddisp, nb-fork, zinb, "
                  "zinb-shared, zinb-conddisp(default) zinb-fork")
+    parser.add_argument('--threads', type=int, default=8,
+            help='Number of threads for training (default:8)')
     parser.add_argument('-b', '--batchsize', type=int, default=32,
             help="Batch size (default:32)")
     parser.add_argument('--sizefactors', dest='sizefactors',

--- a/DCA/__main__.py
+++ b/DCA/__main__.py
@@ -41,8 +41,8 @@ def parse_args():
             help="Type of autoencoder. Possible values: normal, poisson, nb, "
                  "nb-shared, nb-conddisp, nb-fork, zinb, "
                  "zinb-shared, zinb-conddisp(default) zinb-fork")
-    parser.add_argument('--threads', type=int, default=8,
-            help='Number of threads for training (default:8)')
+    parser.add_argument('--threads', type=int, default=None,
+            help='Number of threads for training (default is all cores)')
     parser.add_argument('-b', '--batchsize', type=int, default=32,
             help="Batch size (default:32)")
     parser.add_argument('--sizefactors', dest='sizefactors',

--- a/DCA/train.py
+++ b/DCA/train.py
@@ -32,11 +32,13 @@ from keras import backend as K
 from keras.preprocessing.image import Iterator
 
 
+
 def train(adata, network, output_dir=None, optimizer='rmsprop', learning_rate=None, train_on_full=False,
           aetype=None, epochs=300, reduce_lr=10, output_subset=None,
           early_stop=15, batch_size=32, clip_grad=5., save_weights=False,
-          tensorboard=False, verbose=True, **kwargs):
+          tensorboard=False, verbose=True, threads=8, **kwargs):
 
+    K.set_session(K.tf.Session(config=K.tf.ConfigProto(intra_op_parallelism_threads=threads, inter_op_parallelism_threads=threads)))
     model = network.model
     loss = network.loss
     if output_dir is not None:
@@ -95,6 +97,7 @@ def train(adata, network, output_dir=None, optimizer='rmsprop', learning_rate=No
 
 def train_with_args(args):
 
+    K.set_session(K.tf.Session(config=K.tf.ConfigProto(intra_op_parallelism_threads=args.threads, inter_op_parallelism_threads=args.threads)))
     # set seed for reproducibility
     random.seed(42)
     np.random.seed(42)

--- a/DCA/train.py
+++ b/DCA/train.py
@@ -36,8 +36,8 @@ from keras.preprocessing.image import Iterator
 def train(adata, network, output_dir=None, optimizer='rmsprop', learning_rate=None, train_on_full=False,
           aetype=None, epochs=300, reduce_lr=10, output_subset=None,
           early_stop=15, batch_size=32, clip_grad=5., save_weights=False,
-          tensorboard=False, verbose=True, threads=8, **kwargs):
-
+          tensorboard=False, verbose=True, threads=None, **kwargs):
+    
     K.set_session(K.tf.Session(config=K.tf.ConfigProto(intra_op_parallelism_threads=threads, inter_op_parallelism_threads=threads)))
     model = network.model
     loss = network.loss

--- a/DCA/train.py
+++ b/DCA/train.py
@@ -38,7 +38,7 @@ def train(adata, network, output_dir=None, optimizer='rmsprop', learning_rate=No
           early_stop=15, batch_size=32, clip_grad=5., save_weights=False,
           tensorboard=False, verbose=True, threads=None, **kwargs):
     
-    K.set_session(K.tf.Session(config=K.tf.ConfigProto(intra_op_parallelism_threads=threads, inter_op_parallelism_threads=threads)))
+    K.set_session(tf.Session(config=tf.ConfigProto(intra_op_parallelism_threads=threads, inter_op_parallelism_threads=threads)))
     model = network.model
     loss = network.loss
     if output_dir is not None:
@@ -97,7 +97,7 @@ def train(adata, network, output_dir=None, optimizer='rmsprop', learning_rate=No
 
 def train_with_args(args):
 
-    K.set_session(K.tf.Session(config=K.tf.ConfigProto(intra_op_parallelism_threads=args.threads, inter_op_parallelism_threads=args.threads)))
+    K.set_session(tf.Session(config=tf.ConfigProto(intra_op_parallelism_threads=args.threads, inter_op_parallelism_threads=args.threads)))
     # set seed for reproducibility
     random.seed(42)
     np.random.seed(42)


### PR DESCRIPTION
I added the `--threads` option which sets the number of threads available to the tensorflow backend. Default is still to use everything available, but now it's a bit easier to limit the resources used.