### PR TITLE
Bump tensorflow requirement to <=2.10

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,69 @@
+name: Run Tests
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  cancel_previous_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+  run_tests:
+    needs: cancel_previous_runs
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {python: "3.7", tensorflow: "2.0"}
+        - {python: "3.7", tensorflow: "2.1"}
+        - {python: "3.8", tensorflow: "2.2"}
+        - {python: "3.8", tensorflow: "2.3"}
+        - {python: "3.8", tensorflow: "2.4"}
+        - {python: "3.9", tensorflow: "2.5"}
+        - {python: "3.9", tensorflow: "2.7"}
+        - {python: "3.9", tensorflow: "2.8"}
+        - {python: "3.9", tensorflow: "2.9"}
+        - {python: "3.10", tensorflow: "2.10"}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up environment
+      run: |
+        echo "LINUX_VERSION=$(uname -rs)" >> $GITHUB_ENV
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.config.python }}
+
+    - name: Cache Python packages
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{env.LINUX_VERSION}}-pip-${{ matrix.config.python }}-${{ hashFiles('setup.py') }}
+        restore-keys: ${{env.LINUX_VERSION}}-pip-${{ matrix.config.python }}-
+
+    - name: Install package & dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U wheel setuptools
+        pip install -U .[test] tensorflow==${{ matrix.config.tensorflow }}
+        python -c "import dca"
+
+    - name: Run tests
+      run: pytest -vv

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ build
 *.egg-info
 .Rproj.user
 docs/build
-data/simulation/
+data/
+.idea
+

--- a/dca/__init__.py
+++ b/dca/__init__.py
@@ -1,2 +1,0 @@
-import os
-os.environ['KERAS_BACKEND'] = 'tensorflow'

--- a/dca/__main__.py
+++ b/dca/__main__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-import os, sys, argparse
+import argparse
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Autoencoder')

--- a/dca/api.py
+++ b/dca/api.py
@@ -1,4 +1,4 @@
-import os, tempfile, shutil, random
+import os, random
 import anndata
 import numpy as np
 import scanpy as sc

--- a/dca/hyper.py
+++ b/dca/hyper.py
@@ -5,7 +5,7 @@ import json
 import numpy as np
 from kopt import CompileFN, test_fn
 from hyperopt import fmin, tpe, hp, Trials
-import keras.optimizers as opt
+import tensorflow.keras.optimizers as opt
 
 from . import io
 from .network import AE_types

--- a/dca/io.py
+++ b/dca/io.py
@@ -18,14 +18,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pickle, os, numbers
+import pickle
 
 import numpy as np
 import scipy as sp
 import pandas as pd
 import scanpy as sc
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import scale
 
 
 #TODO: Fix this

--- a/dca/layers.py
+++ b/dca/layers.py
@@ -1,7 +1,6 @@
-from keras.engine.topology import Layer
-from keras.layers import Lambda, Dense
-from keras.engine.base_layer import InputSpec
-from keras import backend as K
+from tensorflow.keras.layers import Layer, Lambda, Dense
+from tensorflow.keras.layers import InputSpec
+from tensorflow.keras import backend as K
 import tensorflow as tf
 
 
@@ -81,5 +80,15 @@ class ElementwiseDense(Dense):
         return output
 
 
-nan2zeroLayer = Lambda(lambda x: tf.where(tf.is_nan(x), tf.zeros_like(x), x))
-ColwiseMultLayer = Lambda(lambda l: l[0]*tf.reshape(l[1], (-1,1)))
+class ColwiseMultLayer(Layer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def build(self, input_shape):
+        super().build(input_shape)
+
+    def call(self, l):
+        return l[0]*tf.reshape(l[1], (-1,1))
+
+    def compute_output_shape(self, input_shape):
+        return input_shape[0]

--- a/dca/loss.py
+++ b/dca/loss.py
@@ -1,6 +1,5 @@
 import numpy as np
 import tensorflow as tf
-from keras import backend as K
 
 
 def _nan2zero(x):

--- a/dca/test.py
+++ b/dca/test.py
@@ -1,59 +1,73 @@
 import numpy as np
 import scanpy as sc
 
+from unittest import TestCase
+
 from .api import dca
 
-def test_api():
-    adata = sc.datasets.paul15()
-    epochs = 1
+class TestAPI(TestCase):
 
-    # simple tests for denoise
-    ret = dca(adata, mode='denoise', copy=True, epochs=epochs, verbose=True)
-    assert not np.allclose(ret.X[:10], adata.X[:10])
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.adata = sc.datasets.paul15()
+        cls.epochs = 1
+        cls.hid_size = (10, 2, 10)
 
-    ret, _ = dca(adata, mode='denoise', ae_type='nb-conddisp', copy=True, epochs=epochs,
-              return_model=True, return_info=True)
-    assert not np.allclose(ret.X[:10], adata.X[:10])
-    assert 'X_dca_dispersion' in ret.obsm_keys()
-    assert _ is not None
+    def test_denoise_simple(self):
+        ret = dca(self.adata, mode='denoise', copy=True, epochs=self.epochs, verbose=True)
+        assert not np.allclose(ret.X[:10], self.adata.X[:10])
 
-    ret = dca(adata, mode='denoise', ae_type='nb', copy=True, epochs=epochs,
-              return_model=False, return_info=True)
-    assert not np.allclose(ret.X[:10], adata.X[:10])
-    assert 'X_dca_dispersion' in ret.var_keys()
+    def test_denoise_nb_conddisp(self):
+        ret, _ = dca(self.adata, mode='denoise', ae_type='nb-conddisp', copy=True, epochs=self.epochs,
+                  return_model=True, return_info=True)
+        assert not np.allclose(ret.X[:10], self.adata.X[:10])
+        assert 'X_dca_dispersion' in ret.obsm_keys()
+        assert _ is not None
 
-    ret = dca(adata, mode='denoise', ae_type='zinb', copy=True, epochs=epochs,
-              return_model=False, return_info=True)
-    assert not np.allclose(ret.X[:10], adata.X[:10])
-    assert 'X_dca_dropout' in ret.obsm_keys()
-    assert 'dca_loss_history' in ret.uns_keys()
+    def test_denoise_nb(self):
+        ret = dca(self.adata, mode='denoise', ae_type='nb', copy=True, epochs=self.epochs,
+                  return_model=False, return_info=True)
+        assert not np.allclose(ret.X[:10], self.adata.X[:10])
+        assert 'X_dca_dispersion' in ret.var_keys()
 
-    ret = dca(adata, mode='denoise', ae_type='zinb-elempi', copy=True, epochs=epochs,
-              return_model=False, return_info=True)
-    assert not np.allclose(ret.X[:10], adata.X[:10])
-    assert 'X_dca_dropout' in ret.obsm_keys()
-    assert 'dca_loss_history' in ret.uns_keys()
+    def test_denoise_zinb(self):
+        ret = dca(self.adata, mode='denoise', ae_type='zinb', copy=True, epochs=self.epochs,
+                  return_model=False, return_info=True)
+        assert not np.allclose(ret.X[:10], self.adata.X[:10])
+        assert 'X_dca_dropout' in ret.obsm_keys()
+        assert 'dca_loss_history' in ret.uns_keys()
 
-    ret = dca(adata, mode='denoise', ae_type='zinb-elempi', copy=True, epochs=epochs,
-              return_model=False, return_info=True, network_kwds={'sharedpi': True})
-    assert not np.allclose(ret.X[:10], adata.X[:10])
-    assert 'X_dca_dropout' in ret.obsm_keys()
-    assert 'dca_loss_history' in ret.uns_keys()
+    def test_denoise_zinb_elempi(self):
+        ret = dca(self.adata, mode='denoise', ae_type='zinb-elempi', copy=True, epochs=self.epochs,
+                  return_model=False, return_info=True)
+        assert not np.allclose(ret.X[:10], self.adata.X[:10])
+        assert 'X_dca_dropout' in ret.obsm_keys()
+        assert 'dca_loss_history' in ret.uns_keys()
 
-    # simple tests for latent
-    hid_size = (10, 2, 10)
-    ret = dca(adata, mode='latent', hidden_size=hid_size, copy=True, epochs=epochs)
-    assert 'X_dca' in ret.obsm_keys()
-    assert ret.obsm['X_dca'].shape[1] == hid_size[1]
+    def test_denoise_zinb_elempi_sharedpi(self):
+        ret = dca(self.adata, mode='denoise', ae_type='zinb-elempi', copy=True, epochs=self.epochs,
+                  return_model=False, return_info=True, network_kwds={'sharedpi': True})
+        assert not np.allclose(ret.X[:10], self.adata.X[:10])
+        assert 'X_dca_dropout' in ret.obsm_keys()
+        assert 'dca_loss_history' in ret.uns_keys()
 
-    ret = dca(adata, mode='latent', ae_type='nb-conddisp', hidden_size=hid_size, copy=True, epochs=epochs)
-    assert 'X_dca' in ret.obsm_keys()
-    assert ret.obsm['X_dca'].shape[1] == hid_size[1]
+    def test_latent_simple(self):
+        # simple tests for latent
+        ret = dca(self.adata, mode='latent', hidden_size=self.hid_size, copy=True, epochs=self.epochs)
+        assert 'X_dca' in ret.obsm_keys()
+        assert ret.obsm['X_dca'].shape[1] == self.hid_size[1]
 
-    ret = dca(adata, mode='latent', ae_type='nb', hidden_size=hid_size, copy=True, epochs=epochs, return_info=True)
-    assert 'X_dca' in ret.obsm_keys()
-    assert ret.obsm['X_dca'].shape[1] == hid_size[1]
+    def test_latent_nb_conddisp(self):
+        ret = dca(self.adata, mode='latent', ae_type='nb-conddisp', hidden_size=self.hid_size, copy=True, epochs=self.epochs)
+        assert 'X_dca' in ret.obsm_keys()
+        assert ret.obsm['X_dca'].shape[1] == self.hid_size[1]
 
-    ret = dca(adata, mode='latent', ae_type='zinb', hidden_size=hid_size, copy=True, epochs=epochs)
-    assert 'X_dca' in ret.obsm_keys()
-    assert ret.obsm['X_dca'].shape[1] == hid_size[1]
+    def test_latent_nb(self):
+        ret = dca(self.adata, mode='latent', ae_type='nb', hidden_size=self.hid_size, copy=True, epochs=self.epochs, return_info=True)
+        assert 'X_dca' in ret.obsm_keys()
+        assert ret.obsm['X_dca'].shape[1] == self.hid_size[1]
+
+    def test_latent_zinb(self):
+        ret = dca(self.adata, mode='latent', ae_type='zinb', hidden_size=self.hid_size, copy=True, epochs=self.epochs)
+        assert 'X_dca' in ret.obsm_keys()
+        assert ret.obsm['X_dca'].shape[1] == self.hid_size[1]

--- a/dca/train.py
+++ b/dca/train.py
@@ -22,14 +22,11 @@ import random
 
 from . import io
 from .network import AE_types
-from .hyper import hyper
 
 import numpy as np
 import tensorflow as tf
-import keras.optimizers as opt
-from keras.callbacks import TensorBoard, ModelCheckpoint, EarlyStopping, ReduceLROnPlateau
-from keras import backend as K
-from keras.preprocessing.image import Iterator
+import tensorflow.keras.optimizers as opt
+from tensorflow.keras.callbacks import TensorBoard, ModelCheckpoint, EarlyStopping, ReduceLROnPlateau
 
 
 def train(adata, network, output_dir=None, optimizer='RMSprop', learning_rate=None,
@@ -38,14 +35,8 @@ def train(adata, network, output_dir=None, optimizer='RMSprop', learning_rate=No
           validation_split=0.1, tensorboard=False, verbose=True, threads=None,
           **kwds):
 
-    tf.compat.v1.keras.backend.set_session(
-        tf.compat.v1.Session(
-            config=tf.compat.v1.ConfigProto(
-                intra_op_parallelism_threads=threads,
-                inter_op_parallelism_threads=threads,
-            )
-        )
-    )
+    tf.config.threading.set_inter_op_parallelism_threads(threads)
+    tf.config.threading.set_intra_op_parallelism_threads(threads)
     model = network.model
     loss = network.loss
     if output_dir is not None:
@@ -102,14 +93,9 @@ def train(adata, network, output_dir=None, optimizer='RMSprop', learning_rate=No
 
 def train_with_args(args):
 
-    tf.compat.v1.keras.backend.set_session(
-        tf.compat.v1.Session(
-            config=tf.compat.v1.ConfigProto(
-                intra_op_parallelism_threads=args.threads,
-                inter_op_parallelism_threads=args.threads,
-            )
-        )
-    )
+
+    tf.config.threading.set_inter_op_parallelism_threads(args.threads)
+    tf.config.threading.set_intra_op_parallelism_threads(args.threads)
     # set seed for reproducibility
     random.seed(42)
     np.random.seed(42)
@@ -118,6 +104,7 @@ def train_with_args(args):
 
     # do hyperpar optimization and exit
     if args.hyper:
+        from .hyper import hyper
         hyper(args)
         return
 

--- a/dca/utils.py
+++ b/dca/utils.py
@@ -1,7 +1,6 @@
 import scanpy as sc
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import seaborn as sns
 import scipy as sp
 import tensorflow as tf

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name='DCA',
-    version='0.3.3',
+    version='0.3.4',
     description='Count autoencoder for scRNA-seq denoising',
     author='Gokcen Eraslan',
     author_email="gokcen.eraslan@gmail.com",
     packages=['dca'],
     install_requires=['numpy>=1.7',
-                      'keras>=2.4,<2.6',
-                      'tensorflow>=2.0,<2.5',
+                      'tensorflow>=2.0,<2.11,!=2.6',
+                      'protobuf<=3.20',
                       'h5py',
                       'six>=1.10.0',
                       'scikit-learn',
@@ -17,6 +17,7 @@ setup(
                       'kopt',
                       'pandas' #for preprocessing
                       ],
+    extras_require={"test":["pytest"]},
     url='https://github.com/theislab/dca',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
DCA is currently incompatible with recent versions of tensorflow. This PR increases compatibility to tf>=2.0,<=2.10, which makes it compatible with openproblems. I've also added some simple Github Actions tests to ensure that these versions are truly supported.